### PR TITLE
Fixed issue/59

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -83,14 +83,9 @@ const Footer = (): JSX.Element => {
 
               {/* ✅ Feedback now goes to GitHub Issues */}
               <li>
-                <a
-                  href="https://github.com/aayush-1709/Drive-Detect/issues"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-blue-500 transition"
-                >
+                <Link to="/feedback" className="hover:text-blue-500 transition">
                   Feedback
-                </a>
+                </Link>
               </li>
 
               <li>


### PR DESCRIPTION
## 🛠 Fix: Feedback Link Redirect Issue (#59)

### 📌 Problem
Previously, clicking the **Feedback** option in the footer redirected users to the GitHub repository instead of showing an in-app feedback interface. This disrupted user experience and caused confusion.

### ✅ Changes Made
- Updated Footer `Feedback` link to route to `/feedback` instead of GitHub.
- Converted the Feedback page into a proper in-app feedback form.
- Maintained GitHub Issues link under "Report Issue" for technical reporting.
- Preserved existing UI theme and design consistency.

### 🎯 Result
Users can now submit feedback directly within the application without leaving the site, improving engagement and usability.

Closes #59