### PR TITLE
feat: Add Navbar to Terms & Conditions Page for Navigation Consistency (#110)

### DIFF
--- a/frontend/src/pages/Terms.tsx
+++ b/frontend/src/pages/Terms.tsx
@@ -1,5 +1,10 @@
+import { Navbar } from '../components/layout/Navbar';
+
 const Terms = (): JSX.Element => {
   return (
+  <>
+    <Navbar />
+
     <section className="min-h-screen bg-[#020202] text-white px-4 sm:px-6 lg:px-8 py-24">
       <div className="max-w-5xl mx-auto">
 
@@ -79,7 +84,8 @@ const Terms = (): JSX.Element => {
         </div>
       </div>
     </section>
-  );
+  </>
+);
 };
 
 export default Terms;


### PR DESCRIPTION
## 📌 Overview

This PR adds the shared Navbar component to the Terms page to maintain consistent navigation across the website.

---

## 🐛 Problem

The `/terms` page did not include the global navigation bar, limiting user navigation flow.

---

## ✅ Solution Implemented

- Imported the existing `Navbar` component
- Rendered it at the top of `Terms.tsx`
- Maintained layout and responsiveness

---

## Screenshots
- Before
<img width="1919" height="961" alt="image" src="https://github.com/user-attachments/assets/ee8e6704-0133-4196-bee7-fab754bc96de" />

- After
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/7a5e10b5-8c1a-4936-ac8d-27698b89e8c3" />

Fixes #110 