### PR TITLE
Make GitHub Stats Dynamic in Features Section (#95)

### DIFF
--- a/frontend/src/components/sections/OpenSource.tsx
+++ b/frontend/src/components/sections/OpenSource.tsx
@@ -1,7 +1,41 @@
 import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
 import { Github, Star, GitBranch, Terminal } from 'lucide-react';
 
 export const OpenSource = () => {
+  const [repoStats, setRepoStats] = useState({
+  stars: "0",
+  forks: "0",
+  license: "Loading..."
+});
+
+const [loading, setLoading] = useState(true);
+useEffect(() => {
+  const fetchRepoStats = async () => {
+    try {
+      const res = await fetch(
+        "https://api.github.com/repos/aayush-1709/Drive-Detect"
+      );
+      const data = await res.json();
+
+      setRepoStats({
+  stars: data.stargazers_count?.toString() || "0",
+  forks: data.forks_count?.toString() || "0",
+  license:
+    data.license?.spdx_id && data.license.spdx_id !== "NOASSERTION"
+      ? data.license.spdx_id
+      : "MIT"
+});
+
+      setLoading(false);
+    } catch (error) {
+      console.error("Failed to fetch GitHub stats:", error);
+      setLoading(false);
+    }
+  };
+
+  fetchRepoStats();
+}, []);
   return (
     <section
       id="opensource"
@@ -46,10 +80,24 @@ export const OpenSource = () => {
         </motion.div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-          <StatCard icon={<Star size={24} />} value="3" label="Stars" />
-          <StatCard icon={<GitBranch size={24} />} value="10+" label="Forks" />
-          <StatCard icon={<Terminal size={24} />} value="MIT" label="License" />
-        </div>
+  <StatCard
+    icon={<Star size={24} />}
+    value={loading ? "..." : repoStats.stars}
+    label="Stars"
+  />
+
+  <StatCard
+    icon={<GitBranch size={24} />}
+    value={loading ? "..." : repoStats.forks}
+    label="Forks"
+  />
+
+  <StatCard
+    icon={<Terminal size={24} />}
+    value={repoStats.license}
+    label="License"
+  />
+</div>
       </div>
     </section>
   );
@@ -61,7 +109,7 @@ const StatCard = ({
   label,
 }: {
   icon: React.ReactNode;
-  value: string;
+  value: string | number;
   label: string;
 }) => {
   return (


### PR DESCRIPTION
## Description
This PR replaces hardcoded GitHub repository statistics with live data fetched from the GitHub API.

## Changes
- Fetch repository stats from GitHub API
- Dynamically display star count, fork count, and license
- Added loading state while fetching data
- Added fallback for license when API returns NOASSERTION

## Benefits
- Always up-to-date repository statistics
- Improved credibility and transparency
- Removes hardcoded values

## Screenshots
- Before
<img width="1146" height="966" alt="image" src="https://github.com/user-attachments/assets/f23dd40c-83f0-4a6a-847a-2ab1ae7fe1c7" />


- After
<img width="1147" height="979" alt="image" src="https://github.com/user-attachments/assets/5c800c3c-41a1-4913-a9e4-821ccbac9378" />


Closes #95 