### PR TITLE
Add Similar Navbar to Live Demo Page

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { UploadZone } from '../components/UploadZone';
 import { ResultCard } from '../components/ResultCard';
-import { Car, Github, ShieldCheck, ArrowLeft } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { ShieldCheck } from 'lucide-react';
+import { Navbar } from '../components/layout/Navbar';
+
 
 interface Prediction {
   class_id: number;
@@ -107,28 +108,9 @@ if (detected.length > 0) {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans selection:bg-blue-100 selection:text-blue-900">
-      
-      {/* Floating Navbar */}
-      <header className="z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border border-gray-200 dark:border-gray-800 rounded-2xl shadow-lg mx-auto mt-0 max-w-3xl left-0 right-0 w-[95%] flex items-center justify-between px-6 h-16 sticky top-6 transition-all duration-300">
-        <div className="flex items-center gap-4">
-          <Link to="/" className="p-2 -ml-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors rounded-full hover:bg-gray-100 dark:hover:bg-gray-800">
-             <ArrowLeft size={20} />
-          </Link>
-          <div className="flex items-center gap-2">
-            <div className="text-blue-600 dark:text-blue-400">
-              <Car size={24} />
-            </div>
-            <span className="font-bold text-xl tracking-tight">DriveDetect</span>
-          </div>
-        </div>
-        <div className="flex items-center gap-4">
-          <a href="https://github.com/aayush-1709/Drive-Detect" target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors">
-            <Github size={20} />
-          </a>
-        </div>
-      </header>
+      <Navbar />
 
-      <main className="pt-24 pb-12 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
+      <main className="py-16 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
         
         {/* Header Section */}
         <div className="text-center mb-16 space-y-4">


### PR DESCRIPTION
This PR replaces the custom floating header on the Live Demo page with the shared Navbar component used on the homepage.

Changes:
- Imported reusable Navbar component
- Removed custom header implementation
- Ensured consistent navigation across pages

Result:
The Live Demo page now matches the main site navigation structure.

Screenshots
- Before
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/637fdee2-7ac9-41a3-9b9a-c47b051ce3bd" />


- After
<img width="1919" height="981" alt="image" src="https://github.com/user-attachments/assets/9d22aea3-ea25-4219-b572-6f74c4ccf55a" />

Closes #122 